### PR TITLE
Changed import path of Child template for consistency and rendering

### DIFF
--- a/setup2/pages/index.vue
+++ b/setup2/pages/index.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import Child from '~components/Child.vue'
+import Child from './../components/Child.vue';
 
 export default {
   components: {


### PR DESCRIPTION
In working through the Intro to Vue course, I hit a small bug when trying to render setup2 in that Child.vue wasn't being found. 

```bash
This dependency was not found:

* ~components/Child.vue in ./node_modules/babel-loader/lib?{"babelrc":false,"cacheDirectory":true,"presets":[["/Users/cvillard/Personal/intro-to-vue/setup2/node_modules/babel-preset-vue-app/dist/index.common.js",{"targets":{"ie":9,"uglify":true}}]]}!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./pages/index.vue

To install it, you can run: npm install --save ~components/Child.vue
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE 127.0.0.1:3000
    at Object._errnoException (util.js:992:11)
    at _exceptionWithHostPort (util.js:1014:20)
    at Server.setupListenHandle [as _listen2] (net.js:1355:14)
    at listenInCluster (net.js:1396:12)
    at GetAddrInfoReqWrap.doListen [as callback] (net.js:1505:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:97:10)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! setup2@1.0.0 dev: `nuxt`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the setup2@1.0.0 dev script.
```

As you can see, the original path used a tilde. I found that MainMenu.vue was using a dot-relative path, so to stay consistent in style and location, I'm offering up this change.

I don't know if the tilde is causing the error because of a difference between *nix home paths or whatever else, but I saw an issue brought up in March with the exact same error and felt it should be addressed. With the change, it renders fine.